### PR TITLE
Use latest stable solidus release

### DIFF
--- a/lib/language_pack/solidus.rb
+++ b/lib/language_pack/solidus.rb
@@ -36,7 +36,7 @@ class LanguagePack::Solidus < LanguagePack::Rails5
     # We add solidus to the Gemfile, and some other heroku niceties
     File.open("Gemfile", 'a') do |f|
       f.puts <<-GEMFILE
-gem 'solidus', :path => '.'
+gem 'solidus'
 gem 'solidus_auth_devise'
 
 gem 'rails_12factor'


### PR DESCRIPTION
Instead of the bleeding edge, use the latest stable version. This may
help make the one click heroku deploy button on the Solidus repository
more robust.